### PR TITLE
Migrate from Sonar to CodeQL fully

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: "CodeQL config"
+
+# Restrict analysis to the source tree (mirrors the former sonar.sources).
+paths:
+  - src
+
+# Skip auto-generated code (mirrors the former sonar.exclusions).
+paths-ignore:
+  - src/main/java/frc/robot/generated

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@
 - **Vision**: PhotonVision + Studica NavX
 - **Build Tool**: Gradle with Spotless formatting
 - **Testing**: JUnit
-- **Code Quality**: SonarQube integration
+- **Code Quality**: CodeQL analysis
 
 ### Package Structure
 
@@ -144,12 +144,12 @@
 - PhotonVision for AprilTag detection
 - Studica NavX for additional IMU support
 - Jama for linear algebra operations
-- SonarQube integration for code quality analysis
+- CodeQL for code quality and security analysis
 
 ## Build System & Quality Tools
 
 - **Spotless**: Automatic code formatting (Google Java Format, JSON, Markdown)
-- **SonarQube**: Code quality analysis integrated with SonarCloud
+- **CodeQL**: Code quality and security analysis via GitHub code scanning
 - **Event Deployment**: Auto-commit on event branches during deployment
 - **JUnit 5**: Unit testing framework
 - **Gradle Tasks**: `./gradlew spotlessApply`, `./gradlew build`, `./gradlew deploy`

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -18,15 +18,12 @@ env:
   JAVA_VERSION: 17
 
 jobs:
-  sonar-scan:
-    name: Sonar scan
+  coverage:
+    name: Coverage
     runs-on: ubuntu-latest
     permissions:
-      checks: write
       code-quality: write
       contents: read
-      pull-requests: write
-      security-events: write
 
     steps:
       - name: Check out repo
@@ -40,13 +37,6 @@ jobs:
           distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
 
-      - name: Cache Sonar packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
       - name: Cache Gradle packages
         uses: actions/cache@v5
         with:
@@ -54,10 +44,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Build and analyze
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build jacocoTestReport sonar --info
+      - name: Build and generate coverage
+        run: ./gradlew build jacocoTestReport
 
       - name: Convert coverage to Cobertura
         run: python3 .github/scripts/jacoco2cobertura.py build/reports/jacoco/test/jacocoTestReport.xml src/main/java > coverage.xml
@@ -99,6 +87,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id "jacoco"
     id "com.peterabeles.gversion" version "1.11.0"
     id "com.diffplug.spotless" version "8.6.0"
-    id "org.sonarqube" version "7.3.1.8318"
     id "edu.wpi.first.GradleRIO" version "2026.2.1"
 }
 
@@ -231,20 +230,5 @@ spotless {
         trimTrailingWhitespace()
         leadingTabsToSpaces(2)
         endWithNewline()
-    }
-}
-
-// SonarQube configuration
-sonar {
-    properties {
-        property "sonar.projectKey", "teamresistance_Drive_Template"
-        property "sonar.organization", "teamresistance"
-        property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.sources", "src"
-        property "sonar.exclusions", "src/main/java/frc/robot/generated/**"
-        property "sonar.coverage.exclusions", "**/*"
-        property "sonar.issue.ignore.multicriteria", "e1"
-        property "sonar.issue.ignore.multicriteria.e1.ruleKey", "java:S1186"
-        property "sonar.issue.ignore.multicriteria.e1.resourceKey", "**/*.java"
     }
 }


### PR DESCRIPTION
The impact from Sonar hasn't been significant and the team is struggling to work with its quality profiles, so move to solely the far-simpler CodeQL for quality checks.
